### PR TITLE
only source configuration files ending with .conf

### DIFF
--- a/corridor-load-config
+++ b/corridor-load-config
@@ -1,6 +1,5 @@
 #!/bin/sh -e
 
-for f in /etc/corridor.d/*[!~]; do
-	case "$f" in *.dpkg-*) continue; esac
+for f in /etc/corridor.d/*.conf; do
 	. "$f"
 done


### PR DESCRIPTION
I think this is the more elegant and convention conform approach that easily suits any case and needs no Debian specific exception.

(Files in the `corridor.d` directory would have to be renamed to end with `.conf`.)