### PR TITLE
only try to disable IPv6 on IPv6 enabled kernels

### DIFF
--- a/corridor-init-forwarding
+++ b/corridor-init-forwarding
@@ -18,4 +18,6 @@ iptables -w -I FORWARD -j CORRIDOR_FORWARD
 sysctl net.ipv4.ip_forward=1
 
 # Disable IPv6 forwarding if the kernel supports IPv6
-sysctl net.ipv6.ip_forward=0 || :
+if test -f /proc/net/if_inet6 ; then
+   sysctl net.ipv6.ip_forward=0
+fi


### PR DESCRIPTION
```
user@corridor:~$ sudo service corridor-init-forwarding status
● corridor-init-forwarding.service - corridor's forwarding
   Loaded: loaded (/lib/systemd/system/corridor-init-forwarding.service; enabled)
   Active: active (exited) since Wed 2016-07-06 21:49:28 CEST; 1min 41s ago
  Process: 4522 ExecStop=/usr/sbin/corridor-stop-forwarding (code=exited, status=0/SUCCESS)
  Process: 4529 ExecStart=/usr/sbin/corridor-init-forwarding (code=exited, status=0/SUCCESS)
 Main PID: 4529 (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/corridor-init-forwarding.service

Jul 06 21:49:28 corridor corridor-init-forwarding[4529]: net.ipv4.ip_forward = 1
Jul 06 21:49:28 corridor corridor-init-forwarding[4529]: sysctl: cannot stat /proc/sys/net/ipv6/ip_forward: No such file or directory
Jul 06 21:49:28 corridor systemd[1]: Started corridor's forwarding.
```

The output in the log `sysctl: cannot stat /proc/sys/net/ipv6/ip_forward: No such file or directory` does not look so pretty. I know it is not an issue, but others will certainly be worried. There please consider this or an alternative fix.