### PR TITLE
delete qubes/systemd/corridor.target.d/qubes-service.conf

### DIFF
--- a/qubes/systemd/corridor.target.d/qubes-service.conf
+++ b/qubes/systemd/corridor.target.d/qubes-service.conf
@@ -1,2 +1,0 @@
-[Unit]
-ConditionPathExists=/var/run/qubes-service/corridor


### PR DESCRIPTION
Currently Whonix repository contains a corridor package that works [for Qubes-Whonix](https://www.whonix.org/wiki/Corridor), but [not out of the box for Debian](https://phabricator.whonix.org/T524#9537). Having distinct packages for Qubes Debian templates and plain Debian would be a shame.

Therefore, please delete qubes/systemd/corridor.target.d/qubes-service.conf. We could re-add it in the more appropriate place in qubes-core-agent.

Related:

* #9 
* #10 
