### PR TITLE
don't enforce /usr/local/etc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ systemd-units: $(UNITS)
 	ronn -r $<
 
 install: man/corridor.8
-	install -d $(DESTDIR)$(SBIN) $(DESTDIR)$(MAN)/man8 $(DESTDIR)/etc/corridor.d $(DESTDIR)/var/lib/corridor $(DESTDIR)/usr/local/etc/corridor.d
+	install -d $(DESTDIR)$(SBIN) $(DESTDIR)$(MAN)/man8 $(DESTDIR)/etc/corridor.d $(DESTDIR)/var/lib/corridor
 	install sbin/* $(DESTDIR)$(SBIN)
 	install -m 644 man/corridor.8 $(DESTDIR)$(MAN)/man8
 	for f in sbin/*; do ln -sf corridor.8 $(DESTDIR)$(MAN)/man8/$${f##*/}.8; done


### PR DESCRIPTION
Removed `$(DESTDIR)/usr/local/etc/corridor.d`.

...If it is required for some reason. What about introducing `ETC`? I mean, like the following...

```
PREFIX ?= /usr/local
SBIN   ?= $(PREFIX)/sbin
SYSTEM ?= $(PREFIX)/lib/systemd/system
MAN    ?= $(PREFIX)/share/man
ETC    ?= $(PREFIX)/etc
```
