### PR TITLE
systemd Documentation=

### DIFF
--- a/systemd/corridor-data.service.in
+++ b/systemd/corridor-data.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=corridor's relay list
+Documentation=https://github.com/rustybird/corridor
 
 [Service]
 ExecStart=@SBIN@/corridor-data

--- a/systemd/corridor-init-forwarding.service.in
+++ b/systemd/corridor-init-forwarding.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=corridor's forwarding
+Documentation=https://github.com/rustybird/corridor
 DefaultDependencies=no
 After=iptables.service systemd-sysctl.service
 Before=network-pre.target

--- a/systemd/corridor-init-logged.service.in
+++ b/systemd/corridor-init-logged.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=corridor's logging
+Documentation=https://github.com/rustybird/corridor
 Requires=corridor-data.service
 After=corridor-data.service
 

--- a/systemd/corridor-init-snat.service.in
+++ b/systemd/corridor-init-snat.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=corridor's source NAT
+Documentation=https://github.com/rustybird/corridor
 After=iptables.service
 
 [Service]


### PR DESCRIPTION
Add Documentation=https://github.com/rustybird/corridor to systemd unit files.

This fixes a lintian warning on Debian.